### PR TITLE
docs: fix grammar typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Stashfi is an on-chain spot trading & strategy layer: limit / stop / stop-limit 
 
 Once the core smart contracts are deployed, it expands into a performance-aligned marketplace where quants publish auditable strategies users can follow while funds remain in their own wallets or vaults.
 
-## 💡 Why It Should Exists
+## 💡 Why It Should Exist
 Centralized exchanges = counterparty & rehypothecation risk.<br>
 Typical DEX UX = Uniswap V3 with no innovation.<br>
 Stashfi bridges the gap: advanced controls + transparent, performance‑based incentives


### PR DESCRIPTION
## Summary
- fix grammar in README heading and sentence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cb753c2f48332a97a5c2a688c22a0